### PR TITLE
Catch the NoSuchAlgorithmException

### DIFF
--- a/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
+++ b/src/main/java/net/acesinc/data/json/generator/JsonDataGenerator.java
@@ -6,6 +6,7 @@
 package net.acesinc.data.json.generator;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,11 @@ public class JsonDataGenerator {
                     }
                     case "http-post": {
                         log.info("Adding HTTP Post Logger with properties: " + elProps);
-                        loggers.add(new HttpPostLogger(elProps));
+                        try {
+                            loggers.add(new HttpPostLogger(elProps));
+                        } catch (NoSuchAlgorithmException ex) {
+                            log.error("http-post Logger unable to initialize", ex);
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
Compiling in my environment leads to this error:
```
unreported exception java.security.NoSuchAlgorithmException; must be caught or declared to be thrown
```

This PR proposes one solution to fixing it, however depending on the use case of configuring the http-post logger there may be better solutions.
 