### PR TITLE
MQTT: Add support for username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ When you start the Generator, it will contact the Druid Overlord and craete a ta
 **MQTT**
 
 An MQTT Producer sends json events to the MQTT broker specified in the config. The following example shows a sample config that sends json events to a locally running MQTT broker listening on the default MQTT port.
+The example also includes the two optional fields: username and password
 
 ```
 {
@@ -201,7 +202,9 @@ An MQTT Producer sends json events to the MQTT broker specified in the config. T
     "broker.port": 1883,
     "topic": "/logevent",
     "clientId": "LogEvent",
-    "qos": 2
+    "qos": 2,
+    "username": "whoami",
+    "password": "whatsmypassword"
 }
 ```
 The MQTT producer support step specific configuration for QOS and Topic. The entire configuration and each item in it are optional. Add an "mqtt" item to the "producerConfig" map:

--- a/src/main/java/net/acesinc/data/json/generator/log/MqttLogger.java
+++ b/src/main/java/net/acesinc/data/json/generator/log/MqttLogger.java
@@ -26,6 +26,8 @@ public class MqttLogger implements EventLogger {
     private static final String TOPIC_PROP_NAME = "topic";
     private static final String CLIENT_ID_PROP_NAME = "clientId";
     private static final String QOS_PROP_NAME = "qos";
+    private static final String USERNAME_PROP_NAME = "username";
+    private static final String PASSWORD_PROP_NAME = "password";
 
     /* Constants for default values */
     private static final String DEFAULT_CLIENT_ID     = "JsonGenerator";
@@ -41,14 +43,25 @@ public class MqttLogger implements EventLogger {
         Integer brokerPort = (Integer) props.get(BROKER_PORT_PROP_NAME);
         String brokerAddress = brokerHost + ":" + brokerPort.toString();
         
-        topic = (String) props.get(TOPIC_PROP_NAME);
         String clientId = (String) props.get(CLIENT_ID_PROP_NAME);
+        String username = (String)props.get(USERNAME_PROP_NAME);
+        String password = (String)props.get(PASSWORD_PROP_NAME);
+
+        topic = (String) props.get(TOPIC_PROP_NAME);
         Integer _qos = (Integer) props.get(QOS_PROP_NAME);
         qos = null == _qos ? DEFAULT_QOS : _qos;
         
-        mqttClient = new MqttClient(brokerAddress, null == clientId ? DEFAULT_CLIENT_ID : clientId);
+        mqttClient = new MqttClient(brokerAddress,
+                null == clientId ? DEFAULT_CLIENT_ID : clientId);
         MqttConnectOptions connOpts = new MqttConnectOptions();
         connOpts.setCleanSession(true);
+        if (null != username) {
+            connOpts.setUserName(username);
+            if (null != password) {
+                connOpts.setPassword(password.toCharArray());
+            }
+        }
+
         log.debug("Connecting to broker: "+brokerAddress);
         mqttClient.connect(connOpts);
         log.debug("Connected");


### PR DESCRIPTION
MQTT brokers support Username and password based ACL. To support such cases the MQTT producer must support the same